### PR TITLE
Initialize React Native with Expo and Node backend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+.expo
+.expo-shared

--- a/README.md
+++ b/README.md
@@ -1,2 +1,53 @@
-# gadeo
-gadeo
+# Gadeo
+
+This repository contains the source code for both the mobile front-end and the Node.js back-end.
+
+## Prerequisites
+
+- Node.js 18 or newer
+- npm or yarn
+- Expo CLI (`npm install -g expo-cli`)
+
+## Front-end (React Native with Expo)
+
+The React Native project lives in `frontend/`.
+
+### Setup
+
+```bash
+cd frontend
+npm install
+```
+
+### Running
+
+Start the Expo development server:
+
+```bash
+npm start
+```
+
+Use `npm run android`, `npm run ios` or `npm run web` to open the app on a device or emulator.
+
+## Back-end (Node.js)
+
+The Node.js back-end lives in `backend/`.
+
+### Setup
+
+```bash
+cd backend
+npm install
+```
+
+### Running
+
+```bash
+npm run dev
+```
+
+This will start an Express server on port `3000`.
+
+## Testing
+
+There are currently no automated tests for either project.

--- a/backend/index.js
+++ b/backend/index.js
@@ -1,0 +1,11 @@
+const express = require('express');
+const app = express();
+const port = process.env.PORT || 3000;
+
+app.get('/', (req, res) => {
+  res.send('Hello from Gadeo backend!');
+});
+
+app.listen(port, () => {
+  console.log(`Server is running on port ${port}`);
+});

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "gadeo-backend",
+  "version": "1.0.0",
+  "main": "index.js",
+  "scripts": {
+    "start": "node index.js",
+    "dev": "nodemon index.js",
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "dependencies": {
+    "express": "^4.18.2"
+  },
+  "devDependencies": {
+    "nodemon": "^2.0.22"
+  }
+}

--- a/frontend/App.js
+++ b/frontend/App.js
@@ -1,0 +1,19 @@
+import React from 'react';
+import { StyleSheet, Text, View } from 'react-native';
+
+export default function App() {
+  return (
+    <View style={styles.container}>
+      <Text>Open up App.js to start working on your app!</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#fff',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+});

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "gadeo-frontend",
+  "version": "1.0.0",
+  "main": "node_modules/expo/AppEntry.js",
+  "scripts": {
+    "start": "expo start",
+    "android": "expo start --android",
+    "ios": "expo start --ios",
+    "web": "expo start --web",
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "dependencies": {
+    "expo": "~49.0.0",
+    "react": "18.2.0",
+    "react-native": "0.72.0"
+  }
+}


### PR DESCRIPTION
## Summary
- scaffold React Native app with Expo in `frontend`
- scaffold Node.js backend with Express in `backend`
- add setup and run instructions to README
- ignore node_modules and expo folders

## Testing
- `npm test` in `backend` *(fails: no tests specified)*
- `npm test` in `frontend` *(fails: no tests specified)*

------
https://chatgpt.com/codex/tasks/task_e_683fab969c00832eae93df4ac1b02efd